### PR TITLE
Export color names as constants

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,30 @@
 const emojiModifierBase = require('unicode-emoji-modifier-base');
 
 const skinTones = [
-	'',
-	'🏻',
-	'🏼',
-	'🏽',
-	'🏾',
-	'🏿'
+	{
+		color: '',
+		name: 'NONE'
+	},
+	{
+		color: '🏻',
+		name: 'WHITE'
+	},
+	{
+		color: '🏼',
+		name: 'CREAM_WHITE'
+	},
+	{
+		color: '🏽',
+		name: 'LIGHT_BROWN'
+	},
+	{
+		color: '🏾',
+		name: 'BROWN'
+	},
+	{
+		color: '🏿',
+		name: 'DARK_BROWN'
+	}
 ];
 
 module.exports = (emoji, type) => {
@@ -18,12 +36,16 @@ module.exports = (emoji, type) => {
 	// TODO: use this instead when targeting Node.js 6
 	// emoji = emoji.replace(/[\u{1f3fb}-\u{1f3ff}]/u, '');
 	skinTones.forEach(x => {
-		emoji = emoji.replace(x, '');
+		emoji = emoji.replace(x.color, '');
 	});
 
 	if (emojiModifierBase.has(emoji.codePointAt(0)) && type !== 0) {
-		emoji += skinTones[type];
+		emoji += skinTones[type].color;
 	}
 
 	return emoji;
 };
+
+skinTones.forEach((x, i) => {
+	Object.defineProperty(module.exports, x.name, {value: i, enumerable: true});
+});

--- a/readme.md
+++ b/readme.md
@@ -17,18 +17,22 @@ $ npm install --save skin-tone
 ```js
 const skinTone = require('skin-tone');
 
-skinTone('👍', skinTone.BROWN); // or skinTone('👍', 4);
+skinTone('👍', skinTone.BROWN);
 //=> '👍🏾'
 
-skinTone('👍', skinTone.WHITE); // or skinTone('👍', 1);
+// or without using the constant (ids described below)
+skinTone('👍', 4);
+//=> '👍🏾
+
+skinTone('👍', skinTone.WHITE);
 //=> '👍🏻'
 
 // can also remove skin tone
-skinTone('👍🏾', skinTone.NONE); // or skinTone('👍🏾', 0);
+skinTone('👍🏾', skinTone.NONE);
 //=> '👍'
 
 // just passes it through when not supported
-skinTone('🦄', skinTone.DARK_BROWN); // or skinTone('🦄', 5);
+skinTone('🦄', skinTone.DARK_BROWN);
 //=> '🦄'
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -35,15 +35,6 @@ skinTone('🦄', skinTone.DARK_BROWN); // or skinTone('🦄', 5);
 
 ## API
 
-### Skin tone color name constants
-
-- `skinTone.NONE = 0`
-- `skinTone.WHITE = 1`
-- `skinTone.CREAM_WHITE = 2`
-- `skinTone.LIGHT_BROWN = 3`
-- `skinTone.BROWN = 4`
-- `skinTone.DARK_BROWN = 5`
-
 ### skinTone(emoji, type)
 
 #### emoji

--- a/readme.md
+++ b/readme.md
@@ -17,23 +17,32 @@ $ npm install --save skin-tone
 ```js
 const skinTone = require('skin-tone');
 
-skinTone('👍', 4);
+skinTone('👍', skinTone.BROWN); // or skinTone('👍', 4);
 //=> '👍🏾'
 
-skinTone('👍', 1);
+skinTone('👍', skinTone.WHITE); // or skinTone('👍', 1);
 //=> '👍🏻'
 
 // can also remove skin tone
-skinTone('👍🏾', 0);
+skinTone('👍🏾', skinTone.NONE); // or skinTone('👍🏾', 0);
 //=> '👍'
 
 // just passes it through when not supported
-skinTone('🦄', 5);
+skinTone('🦄', skinTone.DARK_BROWN); // or skinTone('🦄', 5);
 //=> '🦄'
 ```
 
 
 ## API
+
+### Skin tone color name constants
+
+- `skinTone.NONE = 0`
+- `skinTone.WHITE = 1`
+- `skinTone.CREAM_WHITE = 2`
+- `skinTone.LIGHT_BROWN = 3`
+- `skinTone.BROWN = 4`
+- `skinTone.DARK_BROWN = 5`
 
 ### skinTone(emoji, type)
 
@@ -48,12 +57,12 @@ Emoji to modify.
 Type: `number`<br>
 Values:
 
-- `0` None
-- `1` 🏻 White        *(Fitzpatrick Type-1–2)*
-- `2` 🏼 Cream white  *(Fitzpatrick Type-3)*
-- `3` 🏽 Light brown  *(Fitzpatrick Type-4)*
-- `4` 🏾 Brown        *(Fitzpatrick Type-5)*
-- `5` 🏿 Dark brown   *(Fitzpatrick Type-6)*
+- `skinTone.NONE` / `0`: None
+- `skinTone.WHITE` / `1`: 🏻 White        *(Fitzpatrick Type-1–2)*
+- `skinTone.CREAM_WHITE` / `2`: 🏼 Cream white  *(Fitzpatrick Type-3)*
+- `skinTone.LIGHT_BROWN` / `3`: 🏽 Light brown  *(Fitzpatrick Type-4)*
+- `skinTone.BROWN` / `4`: 🏾 Brown        *(Fitzpatrick Type-5)*
+- `skinTone.DARK_BROWN` / `5`: 🏿 Dark brown   *(Fitzpatrick Type-6)*
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -48,12 +48,12 @@ Emoji to modify.
 Type: `number`<br>
 Values:
 
-- `skinTone.NONE` / `0`: None
-- `skinTone.WHITE` / `1`: 🏻 White        *(Fitzpatrick Type-1–2)*
-- `skinTone.CREAM_WHITE` / `2`: 🏼 Cream white  *(Fitzpatrick Type-3)*
-- `skinTone.LIGHT_BROWN` / `3`: 🏽 Light brown  *(Fitzpatrick Type-4)*
-- `skinTone.BROWN` / `4`: 🏾 Brown        *(Fitzpatrick Type-5)*
-- `skinTone.DARK_BROWN` / `5`: 🏿 Dark brown   *(Fitzpatrick Type-6)*
+- `skinTone.NONE` / `0`: (Removes skin tone)
+- `skinTone.WHITE` / `1`: 🏻         *(Fitzpatrick Type-1–2)*
+- `skinTone.CREAM_WHITE` / `2`: 🏼   *(Fitzpatrick Type-3)*
+- `skinTone.LIGHT_BROWN` / `3`: 🏽   *(Fitzpatrick Type-4)*
+- `skinTone.BROWN` / `4`: 🏾         *(Fitzpatrick Type-5)*
+- `skinTone.DARK_BROWN` / `5`: 🏿    *(Fitzpatrick Type-6)*
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import m from './';
 
-test(t => {
+test('modify skin tone', t => {
 	t.is(m('👍', 0), '👍');
 	t.is(m('👍', 1), '👍🏻');
 	t.is(m('👍', 2), '👍🏼');
@@ -14,7 +14,7 @@ test(t => {
 	t.is(m('👍🏿', 1), '👍🏻');
 });
 
-test('Color name constants', t => {
+test('constants', t => {
 	t.is(m.NONE, 0);
 	t.is(m.WHITE, 1);
 	t.is(m.CREAM_WHITE, 2);

--- a/test.js
+++ b/test.js
@@ -13,3 +13,12 @@ test(t => {
 	t.is(m('🐶', 5), '🐶');
 	t.is(m('👍🏿', 1), '👍🏻');
 });
+
+test('Color name constants', t => {
+	t.is(m.NONE, 0);
+	t.is(m.WHITE, 1);
+	t.is(m.CREAM_WHITE, 2);
+	t.is(m.LIGHT_BROWN, 3);
+	t.is(m.BROWN, 4);
+	t.is(m.DARK_BROWN, 5);
+});


### PR DESCRIPTION
Adds:
- `skinTone.NONE = 0`
- `skinTone.WHITE = 1`
- `skinTone.CREAM_WHITE = 2`
- `skinTone.LIGHT_BROWN = 3`
- `skinTone.BROWN = 4`
- `skinTone.DARK_BROWN = 5`

Includes tests and changes to readme to reflect updated API. 

TODO: bump version. I assume that should be performed when publishing. 
