### PR TITLE
Add support for named types

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,30 @@
 const emojiModifierBase = require('unicode-emoji-modifier-base');
 
 const skinTones = [
-	'',
-	'🏻',
-	'🏼',
-	'🏽',
-	'🏾',
-	'🏿'
+	{
+		color: '',
+		name: 'NONE'
+	},
+	{
+		color: '🏻',
+		name: 'WHITE'
+	},
+	{
+		color: '🏼',
+		name: 'CREAM_WHITE'
+	},
+	{
+		color: '🏽',
+		name: 'LIGHT_BROWN'
+	},
+	{
+		color: '🏾',
+		name: 'BROWN'
+	},
+	{
+		color: '🏿',
+		name: 'DARK_BROWN'
+	}
 ];
 
 module.exports = (emoji, type) => {
@@ -18,12 +36,16 @@ module.exports = (emoji, type) => {
 	// TODO: use this instead when targeting Node.js 6
 	// emoji = emoji.replace(/[\u{1f3fb}-\u{1f3ff}]/u, '');
 	skinTones.forEach(x => {
-		emoji = emoji.replace(x, '');
+		emoji = emoji.replace(x.color, '');
 	});
 
 	if (emojiModifierBase.has(emoji.codePointAt(0)) && type !== 0) {
-		emoji += skinTones[type];
+		emoji += skinTones[type].color;
 	}
 
 	return emoji;
 };
+
+skinTones.forEach((x, i) => {
+	Object.defineProperty(module.exports, x.name, {value: i, enumerable: true});
+});

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const emojiModifierBase = require('unicode-emoji-modifier-base');
+const snakeCase = require('lodash.snakecase');
 
 const skinTones = [
 	{
@@ -28,22 +29,50 @@ const skinTones = [
 	}
 ];
 
-module.exports = (emoji, type) => {
-	if (type > 5 || type < 0) {
-		throw new TypeError(`Expected \`type\` to be a number between 0 and 5, got ${type}`);
-	}
-
+function iterateSkinTones(emoji) {
 	// TODO: use this instead when targeting Node.js 6
 	// emoji = emoji.replace(/[\u{1f3fb}-\u{1f3ff}]/u, '');
 	skinTones.forEach(x => {
 		emoji = emoji.replace(x.color, '');
 	});
+	return emoji;
+}
 
-	if (emojiModifierBase.has(emoji.codePointAt(0)) && type !== 0) {
-		emoji += skinTones[type].color;
+function processEmoji(emoji, skinTone) {
+	if (emojiModifierBase.has(emoji.codePointAt(0)) && skinTones.indexOf(skinTone) > 0) {
+		emoji += skinTone.color;
 	}
 
 	return emoji;
+}
+
+function typeAsNumber(emoji, type) {
+	if (type > 5 || type < 0) {
+		throw new TypeError(`Expected \`type\` to be a number between 0 and 5, got ${type}`);
+	}
+
+	return skinTones[type];
+}
+
+function typeAsString(emoji, type) {
+	const typeAsName = snakeCase(type).toUpperCase();
+	const skinTone = skinTones.filter(x => x.name === typeAsName)[0];
+	if (!skinTone) {
+		throw new TypeError(`Expected \`type\` to be a string matching one of skin tone names, got ${type}`);
+	}
+
+	return skinTone;
+}
+
+module.exports = (emoji, type) => {
+	const fnByType = (() => {
+		switch (typeof type) {
+			case 'number': return typeAsNumber;
+			case 'string': return typeAsString;
+			default: return () => {};
+		}
+	})();
+	return processEmoji(iterateSkinTones(emoji), fnByType(emoji, type));
 };
 
 skinTones.forEach((x, i) => {

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function typeAsNumber(emoji, type) {
 }
 
 function typeAsString(emoji, type) {
-	const typeAsName = snakeCase(type).toUpperCase();
+	const typeAsName = snakeCase(type.replace(/\d/g, ' ')).toUpperCase();
 	const skinTone = skinTones.filter(x => x.name === typeAsName)[0];
 	if (!skinTone) {
 		throw new TypeError(`Expected \`type\` to be a string matching one of skin tone names, got ${type}`);

--- a/index.js
+++ b/index.js
@@ -64,12 +64,16 @@ function typeAsString(emoji, type) {
 	return skinTone;
 }
 
+function typeUnsupported(emoji, type) {
+	throw new TypeError(`Expected \`type\` to be either a number between 0 and 5 or a string matching one of skin tone names, got ${type}`);
+}
+
 module.exports = (emoji, type) => {
 	const fnByType = (() => {
 		switch (typeof type) {
 			case 'number': return typeAsNumber;
 			case 'string': return typeAsString;
-			default: return () => {};
+			default: return typeUnsupported;
 		}
 	})();
 	return processEmoji(iterateSkinTones(emoji), fnByType(emoji, type));

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "remove"
   ],
   "dependencies": {
+    "lodash.snakecase": "^4.0.1",
     "unicode-emoji-modifier-base": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "ava": "*",
+    "lodash.capitalize": "^4.1.1",
     "xo": "*"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -17,18 +17,22 @@ $ npm install --save skin-tone
 ```js
 const skinTone = require('skin-tone');
 
-skinTone('👍', skinTone.BROWN); // or skinTone('👍', 4);
+skinTone('👍', skinTone.BROWN);
 //=> '👍🏾'
 
-skinTone('👍', skinTone.WHITE); // or skinTone('👍', 1);
+// or without using the constant (ids described below)
+skinTone('👍', 4);
+//=> '👍🏾
+
+skinTone('👍', skinTone.WHITE);
 //=> '👍🏻'
 
 // can also remove skin tone
-skinTone('👍🏾', skinTone.NONE); // or skinTone('👍🏾', 0);
+skinTone('👍🏾', skinTone.NONE);
 //=> '👍'
 
 // just passes it through when not supported
-skinTone('🦄', skinTone.DARK_BROWN); // or skinTone('🦄', 5);
+skinTone('🦄', skinTone.DARK_BROWN);
 //=> '🦄'
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -35,15 +35,6 @@ skinTone('🦄', skinTone.DARK_BROWN); // or skinTone('🦄', 5);
 
 ## API
 
-### Skin tone color name constants
-
-- `skinTone.NONE = 0`
-- `skinTone.WHITE = 1`
-- `skinTone.CREAM_WHITE = 2`
-- `skinTone.LIGHT_BROWN = 3`
-- `skinTone.BROWN = 4`
-- `skinTone.DARK_BROWN = 5`
-
 ### skinTone(emoji, type)
 
 #### emoji

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,12 @@ skinTone('👍', skinTone.BROWN);
 skinTone('👍', 4);
 //=> '👍🏾
 
+// can also use name
+skinTone('👍', 'dark');
+//=> '👍🏾
+skinTone('👍', 'dark brown');
+//=> '👍🏿'
+
 skinTone('👍', skinTone.WHITE);
 //=> '👍🏻'
 
@@ -49,8 +55,9 @@ Emoji to modify.
 
 #### type
 
-Type: `number`<br>
-Values:
+Type: `number|string`
+
+Values if `number`:
 
 - `skinTone.NONE` / `0`: (Removes skin tone)
 - `skinTone.WHITE` / `1`: 🏻         *(Fitzpatrick Type-1–2)*
@@ -58,6 +65,22 @@ Values:
 - `skinTone.LIGHT_BROWN` / `3`: 🏽   *(Fitzpatrick Type-4)*
 - `skinTone.BROWN` / `4`: 🏾         *(Fitzpatrick Type-5)*
 - `skinTone.DARK_BROWN` / `5`: 🏿    *(Fitzpatrick Type-6)*
+
+Values if `string`:
+
+Any of the above constants in any capitalization or characters in beweeen. Here are some examples for *(Fitzpatrick Type-6)* (Dark Brown):
+
+- `'DARK_BROWN'`: same as constant name
+- `'dark brown'`: human readable
+- `'dark   brown'`: more spaces
+- `'dark+~:_- *^ %$ #*#brown'`: non-word characters
+
+Any of the above would produce the same result as `skinTone.DARK_BROWN`.
+
+What *does not* work:
+
+- Misspelling: `'dank brown'`
+- Putting space in the middle of a word: `'dark bro wn'`
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -17,23 +17,32 @@ $ npm install --save skin-tone
 ```js
 const skinTone = require('skin-tone');
 
-skinTone('👍', 4);
+skinTone('👍', skinTone.BROWN); // or skinTone('👍', 4);
 //=> '👍🏾'
 
-skinTone('👍', 1);
+skinTone('👍', skinTone.WHITE); // or skinTone('👍', 1);
 //=> '👍🏻'
 
 // can also remove skin tone
-skinTone('👍🏾', 0);
+skinTone('👍🏾', skinTone.NONE); // or skinTone('👍🏾', 0);
 //=> '👍'
 
 // just passes it through when not supported
-skinTone('🦄', 5);
+skinTone('🦄', skinTone.DARK_BROWN); // or skinTone('🦄', 5);
 //=> '🦄'
 ```
 
 
 ## API
+
+### Skin tone color name constants
+
+- `skinTone.NONE = 0`
+- `skinTone.WHITE = 1`
+- `skinTone.CREAM_WHITE = 2`
+- `skinTone.LIGHT_BROWN = 3`
+- `skinTone.BROWN = 4`
+- `skinTone.DARK_BROWN = 5`
 
 ### skinTone(emoji, type)
 
@@ -48,12 +57,12 @@ Emoji to modify.
 Type: `number`<br>
 Values:
 
-- `0` None
-- `1` 🏻 White        *(Fitzpatrick Type-1–2)*
-- `2` 🏼 Cream white  *(Fitzpatrick Type-3)*
-- `3` 🏽 Light brown  *(Fitzpatrick Type-4)*
-- `4` 🏾 Brown        *(Fitzpatrick Type-5)*
-- `5` 🏿 Dark brown   *(Fitzpatrick Type-6)*
+- `skinTone.NONE` / `0`: None
+- `skinTone.WHITE` / `1`: 🏻 White        *(Fitzpatrick Type-1–2)*
+- `skinTone.CREAM_WHITE` / `2`: 🏼 Cream white  *(Fitzpatrick Type-3)*
+- `skinTone.LIGHT_BROWN` / `3`: 🏽 Light brown  *(Fitzpatrick Type-4)*
+- `skinTone.BROWN` / `4`: 🏾 Brown        *(Fitzpatrick Type-5)*
+- `skinTone.DARK_BROWN` / `5`: 🏿 Dark brown   *(Fitzpatrick Type-6)*
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -48,12 +48,12 @@ Emoji to modify.
 Type: `number`<br>
 Values:
 
-- `skinTone.NONE` / `0`: None
-- `skinTone.WHITE` / `1`: 🏻 White        *(Fitzpatrick Type-1–2)*
-- `skinTone.CREAM_WHITE` / `2`: 🏼 Cream white  *(Fitzpatrick Type-3)*
-- `skinTone.LIGHT_BROWN` / `3`: 🏽 Light brown  *(Fitzpatrick Type-4)*
-- `skinTone.BROWN` / `4`: 🏾 Brown        *(Fitzpatrick Type-5)*
-- `skinTone.DARK_BROWN` / `5`: 🏿 Dark brown   *(Fitzpatrick Type-6)*
+- `skinTone.NONE` / `0`: (Removes skin tone)
+- `skinTone.WHITE` / `1`: 🏻         *(Fitzpatrick Type-1–2)*
+- `skinTone.CREAM_WHITE` / `2`: 🏼   *(Fitzpatrick Type-3)*
+- `skinTone.LIGHT_BROWN` / `3`: 🏽   *(Fitzpatrick Type-4)*
+- `skinTone.BROWN` / `4`: 🏾         *(Fitzpatrick Type-5)*
+- `skinTone.DARK_BROWN` / `5`: 🏿    *(Fitzpatrick Type-6)*
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import m from './';
 
-test(t => {
+test('modify skin tone', t => {
 	t.is(m('👍', 0), '👍');
 	t.is(m('👍', 1), '👍🏻');
 	t.is(m('👍', 2), '👍🏼');
@@ -14,7 +14,7 @@ test(t => {
 	t.is(m('👍🏿', 1), '👍🏻');
 });
 
-test('Color name constants', t => {
+test('constants', t => {
 	t.is(m.NONE, 0);
 	t.is(m.WHITE, 1);
 	t.is(m.CREAM_WHITE, 2);

--- a/test.js
+++ b/test.js
@@ -27,6 +27,23 @@ test('string type', t => {
 	testAsString(t, '🐶', 'DARK_BROWN', '🐶');
 	testAsString(t, '👍🏿', 'WHITE', '👍🏻');
 });
+
+test('unexpected inputs', t => {
+	// number out of range
+	t.throws(() => m('👍🏿', -1));
+	t.throws(() => m('👍🏿', 6));
+	// string not matching any name
+	t.throws(() => m('👍🏿', ''));
+	t.throws(() => m('👍🏿', 'blue'));
+	t.throws(() => m('👍🏿', '🦄'));
+	// unrecognized type
+	t.throws(() => m('👍🏿'));
+	t.throws(() => m('👍🏿', null));
+	t.throws(() => m('👍🏿', {}));
+	t.throws(() => m('👍🏿', []));
+	t.throws(() => m('👍🏿', () => {}));
+});
+
 test('constants', t => {
 	t.is(m.NONE, 0);
 	t.is(m.WHITE, 1);

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import capitalize from 'lodash.capitalize';
 import m from './';
 
-test('modify skin tone', t => {
+test('numeric type', t => {
 	t.is(m('👍', 0), '👍');
 	t.is(m('👍', 1), '👍🏻');
 	t.is(m('👍', 2), '👍🏼');

--- a/test.js
+++ b/test.js
@@ -13,3 +13,12 @@ test(t => {
 	t.is(m('🐶', 5), '🐶');
 	t.is(m('👍🏿', 1), '👍🏻');
 });
+
+test('Color name constants', t => {
+	t.is(m.NONE, 0);
+	t.is(m.WHITE, 1);
+	t.is(m.CREAM_WHITE, 2);
+	t.is(m.LIGHT_BROWN, 3);
+	t.is(m.BROWN, 4);
+	t.is(m.DARK_BROWN, 5);
+});

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import capitalize from 'lodash.capitalize';
 import m from './';
 
 test('modify skin tone', t => {
@@ -14,6 +15,18 @@ test('modify skin tone', t => {
 	t.is(m('👍🏿', 1), '👍🏻');
 });
 
+test('string type', t => {
+	testAsString(t, '👍', 'NONE', '👍');
+	testAsString(t, '👍', 'WHITE', '👍🏻');
+	testAsString(t, '👍', 'CREAM_WHITE', '👍🏼');
+	testAsString(t, '👍', 'LIGHT_BROWN', '👍🏽');
+	testAsString(t, '👍', 'BROWN', '👍🏾');
+	testAsString(t, '👍', 'DARK_BROWN', '👍🏿');
+	testAsString(t, '👍🏿', 'NONE', '👍');
+	testAsString(t, '👸', 'LIGHT_BROWN', '👸🏽');
+	testAsString(t, '🐶', 'DARK_BROWN', '🐶');
+	testAsString(t, '👍🏿', 'WHITE', '👍🏻');
+});
 test('constants', t => {
 	t.is(m.NONE, 0);
 	t.is(m.WHITE, 1);
@@ -22,3 +35,35 @@ test('constants', t => {
 	t.is(m.BROWN, 4);
 	t.is(m.DARK_BROWN, 5);
 });
+
+function testAsString(t, emoji, type, expected) {
+	// Generates permutations for given list.
+	const permutations = list => {
+		if (list.length === 0) {
+			return [[]];
+		}
+
+		return list.map((_e, i) => {
+			const copy = list.concat();
+			const ith = copy.splice(i, 1);
+			const rest = permutations(copy);
+			return rest.map(e => ith.concat(e));
+		}).reduce((all, arr) => all.concat(arr), []);
+	};
+	// Apply each given functions to parameter x. applyAllRight does the same, in reverse order.
+	const apply = (x, fns) => fns.reduce((result, fn) => fn(result), x);
+	const applyRight = (x, fns) => apply(x, fns.concat().reverse());
+
+	const constantName = name => name;
+	const upperCaseName = name => name.toUpperCase();
+	const lowerCaseName = name => name.toLowerCase();
+	const capitalizedName = name => capitalize(name);
+	const spacedName = name => name.replace(/_/g, ' ');
+
+	// Generate permutations of mapping functions and test if the module returns expected result.
+	permutations([constantName, upperCaseName, lowerCaseName, capitalizedName, spacedName])
+		.forEach(fns => {
+			t.is(m(emoji, apply(type, fns)), expected);
+			t.is(m(emoji, applyRight(type, fns)), expected);
+		});
+}

--- a/test.js
+++ b/test.js
@@ -76,9 +76,11 @@ function testAsString(t, emoji, type, expected) {
 	const lowerCaseName = name => name.toLowerCase();
 	const capitalizedName = name => capitalize(name);
 	const spacedName = name => name.replace(/_/g, ' ');
+	const addStuff = name => name.replace(/_/g, '_ + -* ~_');
+	const addStuffAndNumbers = name => name.replace(/_/g, '_ + 1-* 3~_');
 
 	// Generate permutations of mapping functions and test if the module returns expected result.
-	permutations([constantName, upperCaseName, lowerCaseName, capitalizedName, spacedName])
+	permutations([constantName, upperCaseName, lowerCaseName, capitalizedName, spacedName, addStuff, addStuffAndNumbers])
 		.forEach(fns => {
 			t.is(m(emoji, apply(type, fns)), expected);
 			t.is(m(emoji, applyRight(type, fns)), expected);


### PR DESCRIPTION
The #1 got me thinking. More specifically, the comment about exporting constants, since that really is an unusual practice. 
This PR is adding support for named skin tones, for example:

``` js
skinTone('👍', 'dark');
//=> '👍🏾
skinTone('👍', 'dark brown');
//=> '👍🏿
```

Full description in readme at the bottom. Basically anything that `lodash.snakecase` can convert to one of the constant names is acceptable as name. 

On a side note, also added check and tests for unexpected `type`, which is any number not in range 0..5, a string not matching any of the constants or any other type. 
